### PR TITLE
URL Cleanup

### DIFF
--- a/gradle/asciidoc.gradle
+++ b/gradle/asciidoc.gradle
@@ -14,7 +14,7 @@ asciidoctor {
             doctype: 'book',
             numbered: '',
 
-            'spring-security-docs-url' : 'http://docs.spring.io/spring-security/site/docs/3.2.x/reference/htmlsingle/#',
+            'spring-security-docs-url' : 'https://docs.spring.io/spring-security/site/docs/3.2.x/reference/htmlsingle/#',
             'spring-security-migration-github-url' : 'https://github.com/spring-projects/spring-security-migrate-3-to-4/'
     }
 

--- a/jc/spring-security-3-jc/pom.xml
+++ b/jc/spring-security-3-jc/pom.xml
@@ -207,7 +207,7 @@
 					<container>
 						<containerId>tomcat7x</containerId>
 						<zipUrlInstaller>
-							<url>http://archive.apache.org/dist/tomcat/tomcat-7/v7.0.30/bin/apache-tomcat-7.0.30.zip</url>
+							<url>https://archive.apache.org/dist/tomcat/tomcat-7/v7.0.30/bin/apache-tomcat-7.0.30.zip</url>
 						</zipUrlInstaller>
 					</container>
 					<configuration>

--- a/jc/spring-security-4-jc/pom.xml
+++ b/jc/spring-security-4-jc/pom.xml
@@ -207,7 +207,7 @@
 					<container>
 						<containerId>tomcat7x</containerId>
 						<zipUrlInstaller>
-							<url>http://archive.apache.org/dist/tomcat/tomcat-7/v7.0.30/bin/apache-tomcat-7.0.30.zip</url>
+							<url>https://archive.apache.org/dist/tomcat/tomcat-7/v7.0.30/bin/apache-tomcat-7.0.30.zip</url>
 						</zipUrlInstaller>
 					</container>
 					<configuration>

--- a/xml/spring-security-3-xml/pom.xml
+++ b/xml/spring-security-3-xml/pom.xml
@@ -207,7 +207,7 @@
 					<container>
 						<containerId>tomcat7x</containerId>
 						<zipUrlInstaller>
-							<url>http://archive.apache.org/dist/tomcat/tomcat-7/v7.0.30/bin/apache-tomcat-7.0.30.zip</url>
+							<url>https://archive.apache.org/dist/tomcat/tomcat-7/v7.0.30/bin/apache-tomcat-7.0.30.zip</url>
 						</zipUrlInstaller>
 					</container>
 					<configuration>

--- a/xml/spring-security-4-xml/pom.xml
+++ b/xml/spring-security-4-xml/pom.xml
@@ -207,7 +207,7 @@
 					<container>
 						<containerId>tomcat7x</containerId>
 						<zipUrlInstaller>
-							<url>http://archive.apache.org/dist/tomcat/tomcat-7/v7.0.30/bin/apache-tomcat-7.0.30.zip</url>
+							<url>https://archive.apache.org/dist/tomcat/tomcat-7/v7.0.30/bin/apache-tomcat-7.0.30.zip</url>
 						</zipUrlInstaller>
 					</container>
 					<configuration>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://archive.apache.org/dist/tomcat/tomcat-7/v7.0.30/bin/apache-tomcat-7.0.30.zip migrated to:  
  https://archive.apache.org/dist/tomcat/tomcat-7/v7.0.30/bin/apache-tomcat-7.0.30.zip ([https](https://archive.apache.org/dist/tomcat/tomcat-7/v7.0.30/bin/apache-tomcat-7.0.30.zip) result 200).
* http://docs.spring.io/spring-security/site/docs/3.2.x/reference/htmlsingle/ migrated to:  
  https://docs.spring.io/spring-security/site/docs/3.2.x/reference/htmlsingle/ ([https](https://docs.spring.io/spring-security/site/docs/3.2.x/reference/htmlsingle/) result 200).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://www.w3.org/2001/XMLSchema-instance