### PR TITLE
URL Cleanup

### DIFF
--- a/jc/spring-security-3-jc/src/main/java/sample/HelloWorldMessageService.java
+++ b/jc/spring-security-3-jc/src/main/java/sample/HelloWorldMessageService.java
@@ -5,7 +5,7 @@
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/jc/spring-security-3-jc/src/main/java/sample/mvc/AuthenticationPrincipalController.java
+++ b/jc/spring-security-3-jc/src/main/java/sample/mvc/AuthenticationPrincipalController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jc/spring-security-3-jc/src/main/java/sample/mvc/LoginController.java
+++ b/jc/spring-security-3-jc/src/main/java/sample/mvc/LoginController.java
@@ -5,7 +5,7 @@
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/jc/spring-security-3-jc/src/test/java/sample/role_/HelloWorldMessageService.java
+++ b/jc/spring-security-3-jc/src/test/java/sample/role_/HelloWorldMessageService.java
@@ -5,7 +5,7 @@
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/jc/spring-security-3-jc/src/test/java/sample/web/AuthenticationPrincipalTests.java
+++ b/jc/spring-security-3-jc/src/test/java/sample/web/AuthenticationPrincipalTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jc/spring-security-4-jc/src/main/java/sample/HelloWorldMessageService.java
+++ b/jc/spring-security-4-jc/src/main/java/sample/HelloWorldMessageService.java
@@ -5,7 +5,7 @@
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/jc/spring-security-4-jc/src/main/java/sample/mvc/AuthenticationPrincipalController.java
+++ b/jc/spring-security-4-jc/src/main/java/sample/mvc/AuthenticationPrincipalController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jc/spring-security-4-jc/src/main/java/sample/mvc/LoginController.java
+++ b/jc/spring-security-4-jc/src/main/java/sample/mvc/LoginController.java
@@ -5,7 +5,7 @@
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/jc/spring-security-4-jc/src/test/java/sample/role_/HelloWorldMessageService.java
+++ b/jc/spring-security-4-jc/src/test/java/sample/role_/HelloWorldMessageService.java
@@ -5,7 +5,7 @@
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/jc/spring-security-4-jc/src/test/java/sample/web/AuthenticationPrincipalTests.java
+++ b/jc/spring-security-4-jc/src/test/java/sample/web/AuthenticationPrincipalTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/xml/spring-security-3-xml/src/main/java/sample/AuthenticationPrincipalController.java
+++ b/xml/spring-security-3-xml/src/main/java/sample/AuthenticationPrincipalController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/xml/spring-security-3-xml/src/main/java/sample/HelloWorldMessageService.java
+++ b/xml/spring-security-3-xml/src/main/java/sample/HelloWorldMessageService.java
@@ -5,7 +5,7 @@
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/xml/spring-security-3-xml/src/main/java/sample/LoginController.java
+++ b/xml/spring-security-3-xml/src/main/java/sample/LoginController.java
@@ -5,7 +5,7 @@
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/xml/spring-security-3-xml/src/test/java/sample/role_/HelloWorldMessageService.java
+++ b/xml/spring-security-3-xml/src/test/java/sample/role_/HelloWorldMessageService.java
@@ -5,7 +5,7 @@
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/xml/spring-security-3-xml/src/test/java/sample/web/AuthenticationPrincipalTests.java
+++ b/xml/spring-security-3-xml/src/test/java/sample/web/AuthenticationPrincipalTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/xml/spring-security-4-xml/src/main/java/sample/AuthenticationPrincipalController.java
+++ b/xml/spring-security-4-xml/src/main/java/sample/AuthenticationPrincipalController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/xml/spring-security-4-xml/src/main/java/sample/HelloWorldMessageService.java
+++ b/xml/spring-security-4-xml/src/main/java/sample/HelloWorldMessageService.java
@@ -5,7 +5,7 @@
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/xml/spring-security-4-xml/src/main/java/sample/LoginController.java
+++ b/xml/spring-security-4-xml/src/main/java/sample/LoginController.java
@@ -5,7 +5,7 @@
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/xml/spring-security-4-xml/src/test/java/sample/role_/HelloWorldMessageService.java
+++ b/xml/spring-security-4-xml/src/test/java/sample/role_/HelloWorldMessageService.java
@@ -5,7 +5,7 @@
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/xml/spring-security-4-xml/src/test/java/sample/web/AuthenticationPrincipalTests.java
+++ b/xml/spring-security-4-xml/src/test/java/sample/web/AuthenticationPrincipalTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.apache.org/licenses/LICENSE-2.0 with 20 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).