### PR TITLE
URL Cleanup

### DIFF
--- a/jc/spring-security-3-jc/pom.xml
+++ b/jc/spring-security-3-jc/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.security.migrate</groupId>
 	<artifactId>spring-security-migrate-3-to-4-jc</artifactId>

--- a/jc/spring-security-4-jc/pom.xml
+++ b/jc/spring-security-4-jc/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.security.migrate</groupId>
 	<artifactId>spring-security-migrate-3-to-4-jc</artifactId>

--- a/xml/spring-security-3-xml/pom.xml
+++ b/xml/spring-security-3-xml/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.security.migrate</groupId>
 	<artifactId>spring-security-migrate-3-to-4-xml</artifactId>

--- a/xml/spring-security-3-xml/src/main/webapp/WEB-INF/spring/mvc/servlet-context.xml
+++ b/xml/spring-security-3-xml/src/main/webapp/WEB-INF/spring/mvc/servlet-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:beans="http://www.springframework.org/schema/beans"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
 	<!-- DispatcherServlet Context: defines this servlet's request-processing infrastructure -->
 	

--- a/xml/spring-security-3-xml/src/main/webapp/WEB-INF/spring/root-context.xml
+++ b/xml/spring-security-3-xml/src/main/webapp/WEB-INF/spring/root-context.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:sec="http://www.springframework.org/schema/security"
-  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+  xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 
 </beans>

--- a/xml/spring-security-3-xml/src/main/webapp/WEB-INF/spring/security.xml
+++ b/xml/spring-security-3-xml/src/main/webapp/WEB-INF/spring/security.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<http>
 		<intercept-url pattern="/login" access="ROLE_ANONYMOUS"/>

--- a/xml/spring-security-3-xml/src/main/webapp/WEB-INF/web.xml
+++ b/xml/spring-security-3-xml/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
 
 	<!-- The definition of the Root Spring Container shared by all Servlets
 		and Filters -->

--- a/xml/spring-security-3-xml/src/test/resources/sample/cas/CasAuthenticationFilterDefaultUrlsTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/cas/CasAuthenticationFilterDefaultUrlsTests-context.xml
@@ -2,8 +2,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<b:bean id="casFilter"
 				class="org.springframework.security.cas.web.CasAuthenticationFilter">

--- a/xml/spring-security-3-xml/src/test/resources/sample/cas/ServiceAuthenticationDetailsSourceTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/cas/ServiceAuthenticationDetailsSourceTests-context.xml
@@ -2,8 +2,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<b:bean class="org.springframework.security.cas.web.authentication.ServiceAuthenticationDetailsSource"/>
 

--- a/xml/spring-security-3-xml/src/test/resources/sample/config/FilterChainMapPathTypeTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/config/FilterChainMapPathTypeTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<b:bean class="org.springframework.security.web.FilterChainProxy">
 		<filter-chain-map path-type="regex">

--- a/xml/spring-security-3-xml/src/test/resources/sample/config/FilterInvocationDefinitionSourceTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/config/FilterInvocationDefinitionSourceTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<filter-invocation-definition-source id="fids">
 		<intercept-url pattern="/**" access="ROLE_USER"/>

--- a/xml/spring-security-3-xml/src/test/resources/sample/config/FilterSecurityMetadataSourcePathTypeTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/config/FilterSecurityMetadataSourcePathTypeTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<filter-security-metadata-source id="fsms" path-type="regex" use-expressions="false">
 		<intercept-url pattern=".*" access="ROLE_ADMIN"/>

--- a/xml/spring-security-3-xml/src/test/resources/sample/config/HeadersTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/config/HeadersTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<http>
 		<headers>

--- a/xml/spring-security-3-xml/src/test/resources/sample/config/HttpAccessDeniedPageTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/config/HttpAccessDeniedPageTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<http access-denied-page="/denied">
 		<intercept-url pattern="/**" access="ROLE_ADMIN"/>

--- a/xml/spring-security-3-xml/src/test/resources/sample/config/HttpPathTypeTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/config/HttpPathTypeTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<http path-type="regex" use-expressions="false">
 		<intercept-url pattern=".*" access="ROLE_ADMIN"/>

--- a/xml/spring-security-3-xml/src/test/resources/sample/core/AbstractAccessDecisionManagerTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/core/AbstractAccessDecisionManagerTests-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
 	xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util-4.1.xsd">
 
 	<b:bean class="org.springframework.security.access.vote.AffirmativeBased">
 		<b:property name="decisionVoters" ref="voters"/>

--- a/xml/spring-security-3-xml/src/test/resources/sample/core/InMemoryDaoImplTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/core/InMemoryDaoImplTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<b:bean class="org.springframework.security.core.userdetails.memory.InMemoryDaoImpl">
 		<b:property name="userProperties">

--- a/xml/spring-security-3-xml/src/test/resources/sample/core/ProviderManagerTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/core/ProviderManagerTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<!-- Example with parent, providers, clearExtraInformation properties -->
 	<b:bean class="org.springframework.security.authentication.ProviderManager">

--- a/xml/spring-security-3-xml/src/test/resources/sample/core/RememberMeAuthenticationProviderTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/core/RememberMeAuthenticationProviderTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<b:bean class="org.springframework.security.authentication.RememberMeAuthenticationProvider">
 		<b:property name="key" value="key"/>

--- a/xml/spring-security-3-xml/src/test/resources/sample/core/UserDetailsServiceWrapperTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/core/UserDetailsServiceWrapperTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<user-service id="userDetailsService">
 		<user name="user" password="password" authorities="ROLE_USER" />

--- a/xml/spring-security-3-xml/src/test/resources/sample/openid/OpenID4JavaConsumerTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/openid/OpenID4JavaConsumerTests-context.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<b:bean class="org.springframework.security.openid.OpenID4JavaConsumer">
 		<b:constructor-arg>
 			<b:list>
 				<b:bean class="org.springframework.security.openid.OpenIDAttribute">
 					<b:constructor-arg value="email"/>
-					<b:constructor-arg value="http://axschema.org/contact/email"/>
+					<b:constructor-arg value="https://axschema.org/contact/email"/>
 				</b:bean>
 			</b:list>
 		</b:constructor-arg>

--- a/xml/spring-security-3-xml/src/test/resources/sample/openid/OpenIDTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/openid/OpenIDTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<http>
 		<openid-login />

--- a/xml/spring-security-3-xml/src/test/resources/sample/role_/RolePrefixTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/role_/RolePrefixTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<http use-expressions="true">
 		<intercept-url access="hasRole('USER')" pattern="/**" />

--- a/xml/spring-security-3-xml/src/test/resources/sample/web/AbstractRememberMeServicesTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/web/AbstractRememberMeServicesTests-context.xml
@@ -2,8 +2,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<b:bean class="org.springframework.security.web.authentication.rememberme.PersistentTokenBasedRememberMeServices">
 		<b:property name="key" value="key"/>

--- a/xml/spring-security-3-xml/src/test/resources/sample/web/AnonymousAuthenticationFilterTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/web/AnonymousAuthenticationFilterTests-context.xml
@@ -2,8 +2,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<b:bean class="org.springframework.security.web.authentication.AnonymousAuthenticationFilter">
 		<b:property name="key" value="key"/>

--- a/xml/spring-security-3-xml/src/test/resources/sample/web/AuthenticationPrincipalTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/web/AuthenticationPrincipalTests-context.xml
@@ -3,9 +3,9 @@
 		 xmlns:mvc="http://www.springframework.org/schema/mvc"
 		 xmlns:security="http://www.springframework.org/schema/security"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-        					http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd
-							http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+        					http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd
+							http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<mvc:annotation-driven>
 		<mvc:argument-resolvers>

--- a/xml/spring-security-3-xml/src/test/resources/sample/web/BasicAuthenticationFilterTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/web/BasicAuthenticationFilterTests-context.xml
@@ -2,8 +2,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<b:bean class="org.springframework.security.web.authentication.www.BasicAuthenticationFilter">
 		<b:property name="authenticationManager" ref="authenticationManager"/>

--- a/xml/spring-security-3-xml/src/test/resources/sample/web/ConcurrentSessionControlStrategyTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/web/ConcurrentSessionControlStrategyTests-context.xml
@@ -2,8 +2,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<b:bean class="org.springframework.security.web.authentication.session.ConcurrentSessionControlStrategy">
 		<b:constructor-arg ref="sessionRegistry"/>

--- a/xml/spring-security-3-xml/src/test/resources/sample/web/ConcurrentSessionFilterTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/web/ConcurrentSessionFilterTests-context.xml
@@ -2,8 +2,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<b:bean class="org.springframework.security.web.session.ConcurrentSessionFilter">
 		<b:property name="sessionRegistry" ref="sessionRegistry"/>

--- a/xml/spring-security-3-xml/src/test/resources/sample/web/ExceptionTranslationFilterTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/web/ExceptionTranslationFilterTests-context.xml
@@ -2,8 +2,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<b:bean class="org.springframework.security.web.access.ExceptionTranslationFilter">
 		<b:property name="authenticationEntryPoint" ref="entryPoint"/>

--- a/xml/spring-security-3-xml/src/test/resources/sample/web/FilterChainProxyTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/web/FilterChainProxyTests-context.xml
@@ -2,8 +2,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<b:bean class="org.springframework.security.web.FilterChainProxy">
 		<b:property name="filterChainMap">

--- a/xml/spring-security-3-xml/src/test/resources/sample/web/LoginUrlAuthenticationEntryPointTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/web/LoginUrlAuthenticationEntryPointTests-context.xml
@@ -2,8 +2,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<b:bean class="org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint">
 		<b:property name="loginFormUrl" value="/login"/>

--- a/xml/spring-security-3-xml/src/test/resources/sample/web/LogoutFilterTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/web/LogoutFilterTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<b:bean id="logoutFilter" class="org.springframework.security.web.authentication.logout.LogoutFilter">
 		<b:constructor-arg value="/logout-success"/>

--- a/xml/spring-security-3-xml/src/test/resources/sample/web/RememberMeAuthenticationFilterTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/web/RememberMeAuthenticationFilterTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<b:bean class="org.springframework.security.web.authentication.rememberme.RememberMeAuthenticationFilter">
 		<b:property name="authenticationManager" ref="authenticationManager"/>

--- a/xml/spring-security-3-xml/src/test/resources/sample/web/RequestCacheAwareFilterTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/web/RequestCacheAwareFilterTests-context.xml
@@ -2,8 +2,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<b:bean class="org.springframework.security.web.savedrequest.RequestCacheAwareFilter">
 		<b:property name="requestCache" ref="requestCache"/>

--- a/xml/spring-security-3-xml/src/test/resources/sample/web/RequestMatcherTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/web/RequestMatcherTests-context.xml
@@ -2,8 +2,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<b:bean class="org.springframework.security.web.util.AntPathRequestMatcher">
 		<b:constructor-arg value="/**"/>

--- a/xml/spring-security-3-xml/src/test/resources/sample/web/SecurityContextPersistenceFilterTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/web/SecurityContextPersistenceFilterTests-context.xml
@@ -2,8 +2,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<b:bean class="org.springframework.security.web.context.SecurityContextPersistenceFilter">
 		<b:property name="securityContextRepository" ref="securityContextRepository"/>

--- a/xml/spring-security-3-xml/src/test/resources/sample/web/SessionManagementFilterTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/web/SessionManagementFilterTests-context.xml
@@ -2,8 +2,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<b:bean class="org.springframework.security.web.session.SessionManagementFilter">
 		<b:constructor-arg ref="securityContextRepository"/>

--- a/xml/spring-security-3-xml/src/test/resources/sample/web/SwitchUserFilterTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/web/SwitchUserFilterTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<b:bean id="switchUserProcessingFilter" class="org.springframework.security.web.authentication.switchuser.SwitchUserFilter">
 		<b:property name="userDetailsService" ref="userDetailsService" />

--- a/xml/spring-security-3-xml/src/test/resources/sample/web/WebSecurityExpressionHandlerTests-context.xml
+++ b/xml/spring-security-3-xml/src/test/resources/sample/web/WebSecurityExpressionHandlerTests-context.xml
@@ -2,8 +2,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<b:bean class="sample.web.WebSecurityExpressionHandlerTests$CustomWebSecurityExpressionHandler"/>
 </b:beans>

--- a/xml/spring-security-4-xml/pom.xml
+++ b/xml/spring-security-4-xml/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.security.migrate</groupId>
 	<artifactId>spring-security-migrate-3-to-4-xml</artifactId>

--- a/xml/spring-security-4-xml/src/main/webapp/WEB-INF/spring/mvc/servlet-context.xml
+++ b/xml/spring-security-4-xml/src/main/webapp/WEB-INF/spring/mvc/servlet-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:beans="http://www.springframework.org/schema/beans"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
 	<!-- DispatcherServlet Context: defines this servlet's request-processing infrastructure -->
 	

--- a/xml/spring-security-4-xml/src/main/webapp/WEB-INF/spring/root-context.xml
+++ b/xml/spring-security-4-xml/src/main/webapp/WEB-INF/spring/root-context.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:sec="http://www.springframework.org/schema/security"
-  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+  xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 
 </beans>

--- a/xml/spring-security-4-xml/src/main/webapp/WEB-INF/spring/security.xml
+++ b/xml/spring-security-4-xml/src/main/webapp/WEB-INF/spring/security.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<http disable-url-rewriting="false">
 		<headers disabled="true"/>

--- a/xml/spring-security-4-xml/src/main/webapp/WEB-INF/web.xml
+++ b/xml/spring-security-4-xml/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
 
 	<!-- The definition of the Root Spring Container shared by all Servlets
 		and Filters -->

--- a/xml/spring-security-4-xml/src/test/resources/sample/cas/CasAuthenticationFilterDefaultUrlsTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/cas/CasAuthenticationFilterDefaultUrlsTests-context.xml
@@ -2,8 +2,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<b:bean id="casFilter"
 				class="org.springframework.security.cas.web.CasAuthenticationFilter">

--- a/xml/spring-security-4-xml/src/test/resources/sample/cas/ServiceAuthenticationDetailsSourceTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/cas/ServiceAuthenticationDetailsSourceTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-			http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+			http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<b:bean class="org.springframework.security.cas.web.authentication.ServiceAuthenticationDetailsSource">
 			<b:constructor-arg ref="serviceProperties" />

--- a/xml/spring-security-4-xml/src/test/resources/sample/config/FilterChainMapPathTypeTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/config/FilterChainMapPathTypeTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<b:bean class="org.springframework.security.web.FilterChainProxy">
 		<filter-chain-map request-matcher="regex">

--- a/xml/spring-security-4-xml/src/test/resources/sample/config/FilterInvocationDefinitionSourceTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/config/FilterInvocationDefinitionSourceTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<filter-security-metadata-source id="fids">
 		<intercept-url pattern="/**" access="ROLE_USER"/>

--- a/xml/spring-security-4-xml/src/test/resources/sample/config/FilterSecurityMetadataSourcePathTypeTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/config/FilterSecurityMetadataSourcePathTypeTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<filter-security-metadata-source id="fsms" request-matcher="regex" use-expressions="false">
 		<intercept-url pattern=".*" access="ROLE_ADMIN"/>

--- a/xml/spring-security-4-xml/src/test/resources/sample/config/HeadersTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/config/HeadersTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<http>
 		<headers defaults-disabled="true">

--- a/xml/spring-security-4-xml/src/test/resources/sample/config/HttpAccessDeniedPageTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/config/HttpAccessDeniedPageTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<http>
 		<access-denied-handler error-page="/denied"/>

--- a/xml/spring-security-4-xml/src/test/resources/sample/config/HttpPathTypeTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/config/HttpPathTypeTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<http request-matcher="regex" use-expressions="false">
 		<intercept-url pattern=".*" access="ROLE_ADMIN"/>

--- a/xml/spring-security-4-xml/src/test/resources/sample/core/AbstractAccessDecisionManagerTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/core/AbstractAccessDecisionManagerTests-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
 	xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util-4.1.xsd">
 
 	<b:bean class="org.springframework.security.access.vote.AffirmativeBased">
 		<b:constructor-arg ref="voters"/>

--- a/xml/spring-security-4-xml/src/test/resources/sample/core/InMemoryDaoImplTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/core/InMemoryDaoImplTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<b:bean class="org.springframework.security.provisioning.InMemoryUserDetailsManager">
 		<b:constructor-arg>

--- a/xml/spring-security-4-xml/src/test/resources/sample/core/ProviderManagerTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/core/ProviderManagerTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<!-- Example with parent, providers, clearExtraInformation properties -->
 	<b:bean class="org.springframework.security.authentication.ProviderManager">

--- a/xml/spring-security-4-xml/src/test/resources/sample/core/RememberMeAuthenticationProviderTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/core/RememberMeAuthenticationProviderTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<b:bean class="org.springframework.security.authentication.RememberMeAuthenticationProvider">
 		<b:constructor-arg value="key"/>

--- a/xml/spring-security-4-xml/src/test/resources/sample/core/UserDetailsServiceWrapperTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/core/UserDetailsServiceWrapperTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<user-service id="userDetailsService">
 		<user name="user" password="password" authorities="ROLE_USER" />

--- a/xml/spring-security-4-xml/src/test/resources/sample/openid/OpenID4JavaConsumerTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/openid/OpenID4JavaConsumerTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<b:bean class="org.springframework.security.openid.OpenID4JavaConsumer">
 		<b:constructor-arg>
@@ -13,7 +13,7 @@
 							<b:list>
 								<b:bean class="org.springframework.security.openid.OpenIDAttribute">
 									<b:constructor-arg value="email"/>
-									<b:constructor-arg value="http://axschema.org/contact/email"/>
+									<b:constructor-arg value="https://axschema.org/contact/email"/>
 								</b:bean>
 							</b:list>
 						</b:entry>

--- a/xml/spring-security-4-xml/src/test/resources/sample/openid/OpenIDTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/openid/OpenIDTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<http>
 		<openid-login login-processing-url="/j_spring_openid_security_check"/>

--- a/xml/spring-security-4-xml/src/test/resources/sample/role_/RolePrefixTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/role_/RolePrefixTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<http use-expressions="true">
 		<intercept-url access="hasRole('USER')" pattern="/**" />

--- a/xml/spring-security-4-xml/src/test/resources/sample/web/AbstractRememberMeServicesTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/web/AbstractRememberMeServicesTests-context.xml
@@ -2,8 +2,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<b:bean class="org.springframework.security.web.authentication.rememberme.PersistentTokenBasedRememberMeServices">
 		<b:constructor-arg value="key"/>

--- a/xml/spring-security-4-xml/src/test/resources/sample/web/AnonymousAuthenticationFilterTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/web/AnonymousAuthenticationFilterTests-context.xml
@@ -2,8 +2,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<b:bean class="org.springframework.security.web.authentication.AnonymousAuthenticationFilter">
 		<b:constructor-arg value="key"/>

--- a/xml/spring-security-4-xml/src/test/resources/sample/web/AuthenticationPrincipalTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/web/AuthenticationPrincipalTests-context.xml
@@ -3,9 +3,9 @@
 		 xmlns:mvc="http://www.springframework.org/schema/mvc"
 		 xmlns:security="http://www.springframework.org/schema/security"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-        					http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd
-							http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+        					http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd
+							http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<mvc:annotation-driven>
 		<mvc:argument-resolvers>

--- a/xml/spring-security-4-xml/src/test/resources/sample/web/BasicAuthenticationFilterTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/web/BasicAuthenticationFilterTests-context.xml
@@ -2,8 +2,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<b:bean class="org.springframework.security.web.authentication.www.BasicAuthenticationFilter">
 		<b:constructor-arg ref="authenticationManager"/>

--- a/xml/spring-security-4-xml/src/test/resources/sample/web/ConcurrentSessionControlStrategyTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/web/ConcurrentSessionControlStrategyTests-context.xml
@@ -2,8 +2,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<b:bean class="org.springframework.security.web.authentication.session.CompositeSessionAuthenticationStrategy">
 		<b:constructor-arg>

--- a/xml/spring-security-4-xml/src/test/resources/sample/web/ConcurrentSessionFilterTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/web/ConcurrentSessionFilterTests-context.xml
@@ -2,8 +2,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<b:bean class="org.springframework.security.web.session.ConcurrentSessionFilter">
 		<b:constructor-arg ref="sessionRegistry"/>

--- a/xml/spring-security-4-xml/src/test/resources/sample/web/ExceptionTranslationFilterTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/web/ExceptionTranslationFilterTests-context.xml
@@ -2,8 +2,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<b:bean class="org.springframework.security.web.access.ExceptionTranslationFilter">
 		<b:constructor-arg ref="entryPoint"/>

--- a/xml/spring-security-4-xml/src/test/resources/sample/web/FilterChainProxyTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/web/FilterChainProxyTests-context.xml
@@ -2,8 +2,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<b:bean class="org.springframework.security.web.FilterChainProxy">
 		<b:constructor-arg>

--- a/xml/spring-security-4-xml/src/test/resources/sample/web/LoginUrlAuthenticationEntryPointTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/web/LoginUrlAuthenticationEntryPointTests-context.xml
@@ -2,8 +2,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<b:bean class="org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint">
 		<b:constructor-arg value="/login"/>

--- a/xml/spring-security-4-xml/src/test/resources/sample/web/LogoutFilterTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/web/LogoutFilterTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<b:bean id="logoutFilter" class="org.springframework.security.web.authentication.logout.LogoutFilter">
 		<b:constructor-arg value="/logout-success"/>

--- a/xml/spring-security-4-xml/src/test/resources/sample/web/RememberMeAuthenticationFilterTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/web/RememberMeAuthenticationFilterTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<b:bean class="org.springframework.security.web.authentication.rememberme.RememberMeAuthenticationFilter">
 		<b:constructor-arg ref="authenticationManager"/>

--- a/xml/spring-security-4-xml/src/test/resources/sample/web/RequestCacheAwareFilterTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/web/RequestCacheAwareFilterTests-context.xml
@@ -2,8 +2,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<b:bean class="org.springframework.security.web.savedrequest.RequestCacheAwareFilter">
 		<b:constructor-arg ref="requestCache"/>

--- a/xml/spring-security-4-xml/src/test/resources/sample/web/RequestMatcherTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/web/RequestMatcherTests-context.xml
@@ -2,8 +2,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<b:bean class="org.springframework.security.web.util.matcher.AntPathRequestMatcher">
 		<b:constructor-arg value="/**"/>

--- a/xml/spring-security-4-xml/src/test/resources/sample/web/SecurityContextPersistenceFilterTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/web/SecurityContextPersistenceFilterTests-context.xml
@@ -2,8 +2,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<b:bean class="org.springframework.security.web.context.SecurityContextPersistenceFilter">
 		<b:constructor-arg ref="securityContextRepository"/>

--- a/xml/spring-security-4-xml/src/test/resources/sample/web/SessionManagementFilterTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/web/SessionManagementFilterTests-context.xml
@@ -2,8 +2,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<b:bean class="org.springframework.security.web.session.SessionManagementFilter">
 		<b:constructor-arg ref="securityContextRepository"/>

--- a/xml/spring-security-4-xml/src/test/resources/sample/web/SwitchUserFilterTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/web/SwitchUserFilterTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<b:bean id="switchUserProcessingFilter" class="org.springframework.security.web.authentication.switchuser.SwitchUserFilter">
 		<b:property name="switchUserUrl" value="/j_spring_security_switch_user" />

--- a/xml/spring-security-4-xml/src/test/resources/sample/web/WebSecurityExpressionHandlerTests-context.xml
+++ b/xml/spring-security-4-xml/src/test/resources/sample/web/WebSecurityExpressionHandlerTests-context.xml
@@ -2,8 +2,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<b:bean class="sample.web.WebSecurityExpressionHandlerTests$CustomWebSecurityExpressionHandler"/>
 </b:beans>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://axschema.org/contact/email (UnknownHostException) with 2 occurrences migrated to:  
  https://axschema.org/contact/email ([https](https://axschema.org/contact/email) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.springframework.org/schema/beans/spring-beans-3.0.xsd with 68 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-3.0.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-3.0.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context-3.0.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context-3.0.xsd ([https](https://www.springframework.org/schema/context/spring-context-3.0.xsd) result 200).
* http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd ([https](https://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd) result 200).
* http://www.springframework.org/schema/mvc/spring-mvc.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/mvc/spring-mvc.xsd ([https](https://www.springframework.org/schema/mvc/spring-mvc.xsd) result 200).
* http://www.springframework.org/schema/security/spring-security.xsd with 68 occurrences migrated to:  
  https://www.springframework.org/schema/security/spring-security.xsd ([https](https://www.springframework.org/schema/security/spring-security.xsd) result 200).
* http://www.springframework.org/schema/util/spring-util-4.1.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util-4.1.xsd ([https](https://www.springframework.org/schema/util/spring-util-4.1.xsd) result 200).
* http://maven.apache.org/maven-v4_0_0.xsd with 4 occurrences migrated to:  
  https://maven.apache.org/maven-v4_0_0.xsd ([https](https://maven.apache.org/maven-v4_0_0.xsd) result 301).
* http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd with 2 occurrences migrated to:  
  https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd ([https](https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd) result 302).

# Ignored
These URLs were intentionally ignored.

* http://jakarta.apache.org/log4j/ with 6 occurrences
* http://java.sun.com/xml/ns/javaee with 4 occurrences
* http://maven.apache.org/POM/4.0.0 with 8 occurrences
* http://www.springframework.org/schema/beans with 144 occurrences
* http://www.springframework.org/schema/context with 4 occurrences
* http://www.springframework.org/schema/mvc with 8 occurrences
* http://www.springframework.org/schema/security with 138 occurrences
* http://www.springframework.org/schema/util with 4 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 78 occurrences