### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
 = Migrating from Spring Security 3.x to 4.x
 
 This project demonstrates how to migrate from Spring Security 3.x to Spring Security 4.x.
-You can find detailed instructions in the http://docs.spring.io/spring-security/site/docs/4.0.x/reference/htmlsingle/#m3to4[Spring Security 4 Reference]
+You can find detailed instructions in the https://docs.spring.io/spring-security/site/docs/4.0.x/reference/htmlsingle/#m3to4[Spring Security 4 Reference]

--- a/jc/spring-security-3-jc/src/test/java/sample/openid/OpenID4JavaConsumerTests.java
+++ b/jc/spring-security-3-jc/src/test/java/sample/openid/OpenID4JavaConsumerTests.java
@@ -15,7 +15,7 @@ public class OpenID4JavaConsumerTests {
 	@Before
 	public void setup() {
 		attributes = Arrays.asList(new OpenIDAttribute("email",
-				"http://axschema.org/contact/email"));
+				"https://axschema.org/contact/email"));
 	}
 
 	@Test

--- a/jc/spring-security-4-jc/src/test/java/sample/openid/OpenID4JavaConsumerTests.java
+++ b/jc/spring-security-4-jc/src/test/java/sample/openid/OpenID4JavaConsumerTests.java
@@ -18,7 +18,7 @@ public class OpenID4JavaConsumerTests {
 	@Before
 	public void setup() {
 		attributes = Arrays.asList(new OpenIDAttribute("email",
-				"http://axschema.org/contact/email"));
+				"https://axschema.org/contact/email"));
 	}
 
 	@Test

--- a/xml/spring-security-3-xml/src/test/java/sample/openid/OpenID4JavaConsumerTests.java
+++ b/xml/spring-security-3-xml/src/test/java/sample/openid/OpenID4JavaConsumerTests.java
@@ -19,7 +19,7 @@ public class OpenID4JavaConsumerTests {
 
 	@Before
 	public void setup() {
-		attributes = Arrays.asList(new OpenIDAttribute("email", "http://axschema.org/contact/email"));
+		attributes = Arrays.asList(new OpenIDAttribute("email", "https://axschema.org/contact/email"));
 	}
 
 	@Test

--- a/xml/spring-security-4-xml/src/test/java/sample/openid/OpenID4JavaConsumerTests.java
+++ b/xml/spring-security-4-xml/src/test/java/sample/openid/OpenID4JavaConsumerTests.java
@@ -22,7 +22,7 @@ public class OpenID4JavaConsumerTests {
 
 	@Before
 	public void setup() {
-		attributes = Arrays.asList(new OpenIDAttribute("email", "http://axschema.org/contact/email"));
+		attributes = Arrays.asList(new OpenIDAttribute("email", "https://axschema.org/contact/email"));
 	}
 
 	@Test

--- a/xml/src/docs/asciidoc/migrate-3-to-4-xml.adoc
+++ b/xml/src/docs/asciidoc/migrate-3-to-4-xml.adoc
@@ -774,7 +774,7 @@ and
 		<b:list>
 			<b:bean class="org.springframework.security.openid.OpenIDAttribute">
 				<b:constructor-arg value="email"/>
-				<b:constructor-arg value="http://axschema.org/contact/email"/>
+				<b:constructor-arg value="https://axschema.org/contact/email"/>
 			</b:bean>
 		</b:list>
 	</b:constructor-arg>
@@ -794,7 +794,7 @@ should be replaced with:
 						<b:list>
 							<b:bean class="org.springframework.security.openid.OpenIDAttribute">
 								<b:constructor-arg value="email"/>
-								<b:constructor-arg value="http://axschema.org/contact/email"/>
+								<b:constructor-arg value="https://axschema.org/contact/email"/>
 							</b:bean>
 						</b:list>
 					</b:entry>
@@ -1994,7 +1994,7 @@ In many instances, leaving the Security HTTP Response Headers enabled will not h
 
 [NOTE]
 ====
-http://docs.spring.io/spring-security/site/docs/current/reference/html/headers.html#headers-hsts[Strict Transport Security] will cause infinite redirects if anywhere within your domain forcefully redirects from HTTPS to HTTP for a subset of pages.
+https://docs.spring.io/spring-security/site/docs/current/reference/html/headers.html#headers-hsts[Strict Transport Security] will cause infinite redirects if anywhere within your domain forcefully redirects from HTTPS to HTTP for a subset of pages.
 If your domain forcfully redirects to HTTP when HTTPS is requested, you will need to ensure to remove the redirect (recommended) or disable Strict Transport Security.
 ====
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://axschema.org/contact/email (UnknownHostException) with 6 occurrences migrated to:  
  https://axschema.org/contact/email ([https](https://axschema.org/contact/email) result UnknownHostException).
* [ ] http://docs.spring.io/spring-security/site/docs/current/reference/html/headers.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/site/docs/current/reference/html/headers.html ([https](https://docs.spring.io/spring-security/site/docs/current/reference/html/headers.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/spring-security/site/docs/4.0.x/reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/site/docs/4.0.x/reference/htmlsingle/ ([https](https://docs.spring.io/spring-security/site/docs/4.0.x/reference/htmlsingle/) result 200).

# Ignored
These URLs were intentionally ignored.

* http://java.sun.com/jsp/jstl/core with 8 occurrences
* http://www.springframework.org/security/tags with 4 occurrences
* http://www.springframework.org/tags/form with 4 occurrences